### PR TITLE
add warning if player did not select the default resource pack or any…

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/itemswapper/ItemSwapperSharedMod.java
+++ b/Shared/src/main/java/dev/tr7zw/itemswapper/ItemSwapperSharedMod.java
@@ -48,6 +48,9 @@ public abstract class ItemSwapperSharedMod {
     public void clientTick() {
         Overlay overlay = Minecraft.getInstance().getOverlay();
         if (keybind.isDown()) {
+            if(!itemGroupManager.isResourcepackSelected()) {
+                this.minecraft.player.displayClientMessage(Component.translatable("text.itemswapper.resourcepack.notSelected").withStyle(ChatFormatting.RED), true);
+            }
             if (!pressed && isModDisabled()) {
                 pressed = true;
                 this.minecraft.gui.setOverlayMessage(

--- a/Shared/src/main/java/dev/tr7zw/itemswapper/manager/ItemGroupManager.java
+++ b/Shared/src/main/java/dev/tr7zw/itemswapper/manager/ItemGroupManager.java
@@ -114,5 +114,13 @@ public class ItemGroupManager {
         }
         return getOpenList(item);
     }
-    
+
+    /**
+     * Checks if resource pack is selected.
+     * @return True if item groups could be loaded, false if at least one Hashmap is empty.
+     */
+    public boolean isResourcepackSelected() {
+        return !mapping.isEmpty() && !secondaryMapping.isEmpty() && !listMapping.isEmpty();
+    }
+
 }

--- a/Shared/src/main/resources/assets/itemswapper/lang/en_us.json
+++ b/Shared/src/main/resources/assets/itemswapper/lang/en_us.json
@@ -12,5 +12,5 @@
     "text.itemswapper.creativeCheatMode": "Creative Cheat Mode",
     "text.itemswapper.confirm.title": "Enable mod on this server?",
     "text.itemswapper.confirm.description": "The server has this mod neither installed nor blocked. Do you want to enable the mod without shulker box support? Please ask the server owner/team for permission first. Using this mod on a server without permission might get you banned!",
-    "text.itemswapper.resourcepack.notSelected": "Warning! Select the resource pack of ItemSwapper to properly work."
+    "text.itemswapper.resourcepack.notSelected": "Warning! No compatible resource pack for ItemSwapper is enabled!"
   }

--- a/Shared/src/main/resources/assets/itemswapper/lang/en_us.json
+++ b/Shared/src/main/resources/assets/itemswapper/lang/en_us.json
@@ -11,5 +11,6 @@
     "text.itemswapper.ignoreHotbar": "Lists Ignore Hotbar",
     "text.itemswapper.creativeCheatMode": "Creative Cheat Mode",
     "text.itemswapper.confirm.title": "Enable mod on this server?",
-    "text.itemswapper.confirm.description": "The server has this mod neither installed nor blocked. Do you want to enable the mod without shulker box support? Please ask the server owner/team for permission first. Using this mod on a server without permission might get you banned!"
+    "text.itemswapper.confirm.description": "The server has this mod neither installed nor blocked. Do you want to enable the mod without shulker box support? Please ask the server owner/team for permission first. Using this mod on a server without permission might get you banned!",
+    "text.itemswapper.resourcepack.notSelected": "Warning! Select the resource pack of ItemSwapper to properly work."
   }


### PR DESCRIPTION
While using it for the first time, I got completely lost, because I did not know about the resource pack I had to select. This is the reason I add a message being displayed if the resource pack is not selected as an improvement.

The check for a selected resource pack is done by checking the Hashmaps in `ItemGroupMangager.java to be empty.
The final result can be seen in the below screenshot.

![grafik](https://user-images.githubusercontent.com/65723138/205501727-af15256e-a9c1-4a22-942a-b6268cf52b4d.png)
