### PR TITLE
fix loading invalid item names from itemsswapper/itemgroups with out warning

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/itemswapper/manager/SwapperResourceLoader.java
+++ b/Shared/src/main/java/dev/tr7zw/itemswapper/manager/SwapperResourceLoader.java
@@ -86,7 +86,7 @@ public class SwapperResourceLoader extends SimpleJsonResourceReloadListener {
             if(el.isJsonPrimitive()) {
                 ResourceLocation resourceLocation = new ResourceLocation(el.getAsString());
                 Item item = Registry.ITEM.get(resourceLocation);
-                if(item == null) {
+                if(item.equals(Items.AIR)) {
                     ItemSwapperSharedMod.LOGGER.warn("Unknown item: " + el.getAsString());
                     if(pallet) {
                         // For unknown items, don't move the rest of the wheel


### PR DESCRIPTION
Items that do not exist in the Registry of the game, were skipped, and no warning was logged.

Boolean expression in line 89 was always false, because if resourceLocation contained an invalid name variable item is gets Blocks.AIR assigned to. This causes the loop to completly ignore the case and not displaying a warning in the log.

I might a further commit that makes the methods a bit more understandable. Not sure right now.