### PR TITLE
Sinicized for the mod

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/itemswapper/overlay/ItemListOverlay.java
+++ b/Shared/src/main/java/dev/tr7zw/itemswapper/overlay/ItemListOverlay.java
@@ -6,10 +6,12 @@ import java.util.List;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import dev.tr7zw.itemswapper.util.DummyScreen;
 import dev.tr7zw.itemswapper.util.ItemUtil;
 import dev.tr7zw.itemswapper.util.NetworkLogic;
 import dev.tr7zw.itemswapper.util.ItemUtil.Slot;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.resources.ResourceLocation;
@@ -27,6 +29,7 @@ public class ItemListOverlay extends XTOverlay {
     private static final int slotSize = 22;
     private final Minecraft minecraft = Minecraft.getInstance();
     private final ItemRenderer itemRenderer = minecraft.getItemRenderer();
+    private final DummyScreen dummyScreen = new DummyScreen(); 
     private Item[] itemSelection;
     private List<Slot> entries = new ArrayList<>();
     private int selectedEntry = 0;
@@ -39,6 +42,7 @@ public class ItemListOverlay extends XTOverlay {
 
     @Override
     public void render(PoseStack poseStack, int paramInt1, int paramInt2, float paramFloat) {
+        dummyScreen.init(minecraft, minecraft.getWindow().getGuiScaledWidth(), minecraft.getWindow().getGuiScaledHeight());
         RenderSystem.enableBlend();
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
@@ -115,6 +119,7 @@ public class ItemListOverlay extends XTOverlay {
         });
         if (selectedEntry == id) {
             blit(poseStack, x-1, y, 0, 22, 24, 24);
+            itemRenderList.add(() -> dummyScreen.renderTooltip(poseStack, slot.item(), x+25 + minecraft.font.width(slot.item().getHoverName()), y+5));
         }
     }
 

--- a/Shared/src/main/java/dev/tr7zw/itemswapper/util/DummyScreen.java
+++ b/Shared/src/main/java/dev/tr7zw/itemswapper/util/DummyScreen.java
@@ -1,0 +1,21 @@
+package dev.tr7zw.itemswapper.util;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+
+public class DummyScreen extends Screen {
+
+    public DummyScreen() {
+        super(Component.empty());
+    }
+
+    @Override
+    public void renderTooltip(PoseStack poseStack, ItemStack itemStack, int i, int j) {
+        super.renderTooltip(poseStack, itemStack, i, j);
+    }
+    
+}


### PR DESCRIPTION
{
  "config.invmove.title": "InvMove 配置",
  "key.invmove.category.general": "基础",
  "key.invmove.category.movement": "UI 移动",
  "key.invmove.category.background": "UI 背景",

  "config.invmove.general.enable": "启用 Mod",
  "tooltip.config.invmove.general.enable": "启用整个 Mod",
  "config.invmove.general.debugDisplay": "调试显示",
  "tooltip.config.invmove.general.debugDisplay": "启用调试显示.",

  "config.invmove.movement.enable": "移动库存",
  "tooltip.config.invmove.movement.enable": "在库存中允许移动.\n您可以手动关闭下面的某些库存.\n有一个键绑定,你可以设置切换.",
  "config.invmove.movement.sneak": "潜行模式",
  "tooltip.config.invmove.movement.sneak": "如何在库存内部处理潜行:\nOff = 不潜行\n打开库存时保持潜行\n按下 = 潜行仅当持有潜行按钮\n(按下可以分散shift点击)\n(如果使用切换潜行，按下允许切换和其他两种模式保持)",
  "config.invmove.movement.jump": "允许跳跃",
  "tooltip.config.invmove.movement.jump": "允许在库存内跳跃.",
  "config.invmove.movement.dismount": "允许拆下",
  "tooltip.config.invmove.movement.dismount": "允许在库存内拆卸.",
  "config.invmove.movement.textFieldDisables": "文本字段禁止移动",
  "tooltip.config.invmove.movement.textFieldDisables": "当文本字段被聚焦时禁用目录的移动.",
  "config.invmove.movement.unrecognizedScreenDefault": "无法识别的屏幕默认值",
  "tooltip.config.invmove.movement.unrecognizedScreenDefault": "无法识别新的UI默认状态.",

  "config.invmove.background.enable": "隐藏库存背景",
  "tooltip.config.invmove.background.enable": "在库存中隐藏背景色.\n您可以手动关闭以下某些库存.",
  "config.invmove.background.hideOnPause": "暂停屏幕背景",
  "tooltip.config.invmove.background.hideOnPause": "如何处理暂停游戏的屏幕:\n显示 = 总是显示背景\n显示SP =显示背景在单人游戏，否则允许隐藏\n允许隐藏 = 允许背景被隐藏",
  "config.invmove.background.unrecognizedScreenDefault": "无法识别的屏幕默认值",
  "tooltip.config.invmove.background.unrecognizedScreenDefault": "无法识别新的UI默认状态.",

  "key.invmove.module.nooptions": "此模块没有任何选项.",

  "key.invmove.unrecognized": "无法识别的UI类型",
  "key.invmove.unrecognized.desc": "一旦与不可识别的gui进行交互,就会在这里显示.",

  "keycategory.invmove": "库存移动",
  "keybind.invmove.toggleMove": "切换UI移动",

  "key.invmove.module.vanilla": "香草",

  "config.invmove.vanilla.movement.horseInventory": "马的库存",
  "config.invmove.vanilla.backgroundHide.horseInventory": "马的库存",
  "tooltip.gui.advancements": "这个菜单是一个暂停屏幕，所以这个选项可能会被覆盖.",
  "tooltip.item.minecraft.book": "这个菜单是一个暂停屏幕，所以这个选项可能会被覆盖."
}
