### PR TITLE
Fix inconsistency in documentation

### DIFF
--- a/docs/4. Palette Modifications.md
+++ b/docs/4. Palette Modifications.md
@@ -6,7 +6,7 @@ Palette Modification files define how to modify existing palettes in the game. T
 
 The file is a JSON object with the following keys:
 
-- `type`: (string) Required. Must be set to "palette_modification".
+- `type`: (string) Required. Must be set to "paletteModification".
 - `target`: (string) Required. A resource location string for the target palette to modify. Invalid palettes will be ignored.
 - `addItems`: (array) Optional. An array of items to be added to the target palette. Items can be specified as a simple string (resource location), or as an object with additional properties.
 - `removeItems`: (array) Optional. An array of items to be removed from the target palette. Items can be specified as a simple string (resource location).

--- a/docs/5. List Modifications.md
+++ b/docs/5. List Modifications.md
@@ -6,7 +6,7 @@ List Modification files define how to modify existing lists in the game. The mai
 
 The file is a JSON object with the following keys:
 
-- `type`: (string) Required. Must be set to "list_modification".
+- `type`: (string) Required. Must be set to "listModification".
 - `target`: (string) Required. A resource location string for the target list to modify. Invalid lists will be ignored.
 - `addItems`: (array) Optional. An array of items to be added to the target list. Items can be specified as a simple string (resource location).
 - `removeItems`: (array) Optional. An array of items to be removed from the target list. Items can be specified as a simple string (resource location).


### PR DESCRIPTION
I noticed that the `type` for Palette Modification and List Modification resources in the documentation were `palette_modification` and `list_modification` respectively, meanwhile the example JSON as well as the resource loader code say they should be `paletteModification` and `listModification`. 