### PR TITLE
Fix bug in overlay when tool is in top left slot

### DIFF
--- a/src/main/java/dev/tr7zw/itemswapper/manager/ClientProviderManager.java
+++ b/src/main/java/dev/tr7zw/itemswapper/manager/ClientProviderManager.java
@@ -74,7 +74,7 @@ public class ClientProviderManager {
             if (itemStack.isEmpty() && item != Items.AIR) {
                 continue;
             }
-            if ((!ignoreHotbar || i > 9) && itemStack.getItem() == item) {
+            if ((!ignoreHotbar || i >= 9) && itemStack.getItem() == item) {
                 addUnstackableItems(ids, new AvailableSlot(-1, i, items.get(i)));
                 if (limit) {
                     return ids;


### PR DESCRIPTION
Related to #220

Fix the issue where the tool in the top left slot of the inventory does not show up in the overlay when pressing the hotkey.

* Adjust the loop condition in the `findSlotsMatchingItem` method in `src/main/java/dev/tr7zw/itemswapper/manager/ClientProviderManager.java` to include the first inventory slot even when the hotbar is ignored.
* Change the condition `i > 9` to `i >= 9` in the `findSlotsMatchingItem` method.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tr7zw/ItemSwapper/issues/220?shareId=64277d02-af88-4279-b6d2-5c847853e7dc).