### PR TITLE
Add toggle option to hide inventory button

### DIFF
--- a/XTVersionless/src/main/java/dev/tr7zw/itemswapper/config/Config.java
+++ b/XTVersionless/src/main/java/dev/tr7zw/itemswapper/config/Config.java
@@ -23,5 +23,6 @@ public class Config {
     public boolean alwaysInventory = false;
     public boolean showHotbar = false;
     public boolean rememberPalette = false;
+    public boolean showOpenInventoryButton = true;
 
 }

--- a/src/main/java/dev/tr7zw/itemswapper/ConfigScreenProvider.java
+++ b/src/main/java/dev/tr7zw/itemswapper/ConfigScreenProvider.java
@@ -46,6 +46,9 @@ public class ConfigScreenProvider {
                 options.add(getOnOffOption("text.itemswapper.disableShulkers",
                         () -> configManager.getConfig().disableShulkers,
                         b -> configManager.getConfig().disableShulkers = b));
+                options.add(getOnOffOption("text.itemswapper.showOpenInventoryButton",
+                        () -> configManager.getConfig().showOpenInventoryButton,
+                        b -> configManager.getConfig().showOpenInventoryButton = b));
 
                 options.add(getDoubleOption("text.itemswapper.controllerSpeed", 1, 16, 0.1f,
                         () -> (double) configManager.getConfig().controllerSpeed,

--- a/src/main/java/dev/tr7zw/itemswapper/overlay/SwitchItemOverlay.java
+++ b/src/main/java/dev/tr7zw/itemswapper/overlay/SwitchItemOverlay.java
@@ -103,7 +103,9 @@ public class SwitchItemOverlay extends ItemSwapperUIAbstractInput {
         if (ItemSwapperSharedMod.instance.isEnableRefill()) {
             shortcutList.add(new RestockShortcut());
         }
-        shortcutList.add(new OpenInventoryShortcut(this));
+        if (configManager.getConfig().showOpenInventoryButton) {
+            shortcutList.add(new OpenInventoryShortcut(this));
+        }
         shortcutList.add(new BackShortcut(this));
         shortcutList.add(new LinkShortcut(getResourceLocation("itemswapper", "v2/main"),
                 ComponentProvider.translatable("text.itemswapper.overview"), null));

--- a/src/main/resources/assets/itemswapper/lang/en_us.json
+++ b/src/main/resources/assets/itemswapper/lang/en_us.json
@@ -78,5 +78,7 @@
     "text.itemswapper.showHotbar": "Show Hotbar",
     "text.itemswapper.showHotbar.tooltip": "Show the hotbar in the Inventory UI.",
     "text.itemswapper.rememberPalette": "Remember Palette",
-    "text.itemswapper.rememberPalette.tooltip": "Remember the last palette you used for each item and open it again when you open the UI with that item."
+    "text.itemswapper.rememberPalette.tooltip": "Remember the last palette you used for each item and open it again when you open the UI with that item.",
+    "text.itemswapper.showOpenInventoryButton": "Show Open Inventory Button",
+    "text.itemswapper.showOpenInventoryButton.tooltip": "Show or hide the open inventory button in the UI."
 }


### PR DESCRIPTION
Fixes #216

(Further testing of the preview Copilot Workspace tool)

Add a toggle option to enable or disable the open inventory button in the settings menu.

* **ConfigScreenProvider.java**: Add an option to toggle the open inventory button in the settings menu using the `showOpenInventoryButton` field from the `Config` class.
* **Config.java**: Add a boolean field `showOpenInventoryButton` to toggle the open inventory button.
* **SwitchItemOverlay.java**: Check the `showOpenInventoryButton` configuration setting to determine the visibility of the open inventory button.
* **en_us.json**: Add the text for the new configuration option to toggle the open inventory button.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tr7zw/ItemSwapper/issues/216?shareId=035e68fd-371a-4df7-9f67-4e0b1b6d1a11).